### PR TITLE
made non-default boincdatadir path OS agnostic

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1169,13 +1169,13 @@ try
 
 	printf("loading cpids...");
 
-	std::string sourcefile = GetBoincDataDir() + "boinc\\client_state.xml";
+	std::string sourcefile = GetBoincDataDir() + "client_state.xml";
     std::string sout = "";
     sout = getfilecontents(sourcefile);
 	if (sout == "-1") 
 	{
 		printf("Unable to obtain Boinc CPIDs \r\n");
-		printf("Please set boincdatadir=c:\\programdata\\  \r\n");
+		printf("Please set boincdatadir=c:\\programdata\\boinc\\  \r\n");
 		return;
 	}
 	if (cleardata)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1099,7 +1099,7 @@ std::string GetBoincDataDir()
     } 
 	else 
 	{
-        path = "c:\\programdata\\";
+        path = "c:\\programdata\\boinc\\";
     }
     return path;
 }


### PR DESCRIPTION
simple change that makes harvesting of CPIDs with native clients on operating systems with unix-like directory separators possible.
