### PR TITLE
Added target definition for C files to OSX makefile

### DIFF
--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -126,8 +126,8 @@ endif
 
 all: gridcoind
 
-test check: test_litecoin FORCE
-	./test_litecoin
+test check: test_gridcoin FORCE
+	./test_gridcoin
 
 #
 # LevelDB support
@@ -154,7 +154,14 @@ obj/%.o: %.cpp
 	      -e '/^$$/ d' -e 's/$$/ :/' < $(@:%.o=%.d) >> $(@:%.o=%.P); \
 	  rm -f $(@:%.o=%.d)
 
-litecoind: $(OBJS:obj/%=obj/%)
+obj/%.o: %.c
+    $(CXX) -c $(CFLAGS) -f permissive -MMD -MF $(@:%.o=%.d) -o $@ $<
+    @cp $(@:%.o=%.d) $(@:%.o=%.P); \
+      sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
+          -e '/^$$/ d' -e 's/$$/ :/' < $(@:%.o=%.d) >> $(@:%.o=%.P); \
+      rm -f $(@:%.o=%.d)
+
+gridcoind: $(OBJS:obj/%=obj/%)
 	$(CXX) $(CFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS)
 
 TESTOBJS := $(patsubst test/%.cpp,obj-test/%.o,$(wildcard test/*.cpp))
@@ -166,11 +173,11 @@ obj-test/%.o: test/%.cpp
 	      -e '/^$$/ d' -e 's/$$/ :/' < $(@:%.o=%.d) >> $(@:%.o=%.P); \
 	  rm -f $(@:%.o=%.d)
 
-test_litecoin: $(TESTOBJS) $(filter-out obj/init.o,$(OBJS:obj/%=obj/%))
+test_gridcoin: $(TESTOBJS) $(filter-out obj/init.o,$(OBJS:obj/%=obj/%))
 	$(CXX) $(CFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS) $(TESTLIBS)
 
 clean:
-	-rm -f litecoind test_litecoin
+	-rm -f gridcoind test_gridcoin
 	-rm -f obj/*.o
 	-rm -f obj-test/*.o
 	-rm -f obj/*.P


### PR DESCRIPTION
New hashing functions used in CPU Mining were not found during compiling since they are C files and the OSX makefile lacked a target definition for these. 
Also took the liberty of changing 'litecoin' occurrences to 'gridcoin'.
